### PR TITLE
Rewrote bin/compile to save dotfiles in the repo root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
-Add as a first buildpack in the chain. Set `PROJECT_PATH` environment variable to point to project root. It will be promoted to slug's root, everything else will be erased. Following buildpack (e.g. nodejs) will finish slug compilation.
+# Subdir buildpack
 
-**Disclaimer:** I may change the code without notice, so always pin to specific github version. Provided as is.
+This buildpack is used to deploy an application to Heroku from a subdirectory of a git repository, rather than from the repository root. It is based on [timanovsky's subdir-heroku-buildpack](https://github.com/timanovsky/subdir-heroku-buildpack).
 
-# How to use:
-1. `heroku buildpacks:clear` if necessary
-2. `heroku buildpacks:set https://github.com/timanovsky/subdir-heroku-buildpack`
-3. `heroku buildpacks:add heroku/nodejs` or whatever buildpack you need for your application
-4. `heroku config:set PROJECT_PATH=projects/nodejs/frontend` pointing to what you want to be a project root.
-5. Deploy your project to Heroku.
+When this buildpack is set to be the first buildpack in the Heroku build chain, application deployment from a subdirectory happens in three steps:
 
-# How it works
-The buildpack takes subdirectory you configured, erases everything else, and copies that subdirectory to project root. Then normal Heroku slug compilation proceeds.
+ 1. The contents of the directory specified by `PROJECT_PATH` are saved in a temporary location.
+ 2. All non-hidden files are deleted from the repository root.
+ 3. The contents of the temporary directory are copied into the repository root.
+
+## Usage
+
+Add this buildpack as the first (or one of the first) buildpacks in your application's build chain. It must certainly appear before any buildpacks that expect to be able to operate on the root directory. You must also set the `PROJECT_PATH` configuration variable on your application to indicate the subdirectory to deploy.
+
+To prepend this buildpack to your application's build chain, run the command:
+
+    heroku buildpacks:add --index=1 --app=<your-app-name> https://github.com/owenniles/subdir-heroku-buildpack.git
+
+To set the `PROJECT_PATH` configuration variable, run the command:
+
+    heroku config:set --app=<your-app-name> PROJECT_PATH=<path/to/subdirectory>

--- a/bin/compile
+++ b/bin/compile
@@ -1,33 +1,39 @@
 #!/usr/bin/env bash
-# bin/compile <build-dir> <cache-dir> <env-dir>
 
-BUILD_DIR=${1:-}
-CACHE_DIR=${2:-}
-ENV_DIR=${3:-}
+# compile
 
-if [ -f $ENV_DIR/PROJECT_PATH ]; then
-	PROJECT_PATH=`cat $ENV_DIR/PROJECT_PATH`
-	if [ -d $BUILD_DIR/$PROJECT_PATH ]; then
-		echo "-----> Subdir buildpack in $PROJECT_PATH"
-		echo "       creating cache: $CACHE_DIR"
-		mkdir -p $CACHE_DIR
-		TMP_DIR=`mktemp -d $CACHE_DIR/subdirXXXXX`
-		echo "       created tmp dir: $TMP_DIR"
-		echo "       moving working dir: $PROJECT_PATH to $TMP_DIR"
-		cp -R $BUILD_DIR/$PROJECT_PATH/. $TMP_DIR/
-	 	echo "       cleaning build dir $BUILD_DIR"
-		rm -rf $BUILD_DIR
-		echo "       recreating $BUILD_DIR"
-		mkdir -p $BUILD_DIR
-		echo "       copying preserved work dir from cache $TMP_DIR to build dir $BUILD_DIR"
-		cp -R $TMP_DIR/. $BUILD_DIR/
-		echo "       cleaning tmp dir $TMP_DIR"
-		rm -rf $TMP_DIR
-		exit 0
-	fi
+# Replace the contents of the root directory with the contents of PROJECT_PATH. Dotfiles in the
+# original root directory will not be modified unless there is a dotfile with the same name in
+# PROJECT_PATH. In that case, the dotfile in the root will be overwritten.
+
+BUILD_DIR=$1
+CACHE_DIR=$2
+ENV_DIR=$3
+
+if [ ! -f "$ENV_DIR"/PROJECT_PATH ]; then
+    echo "       'PROJECT_PATH' is undefined."
+    exit 1
 fi
 
-echo "PROJECT_PATH is undefined"
-exit 1
+PROJECT_PATH=$(cat "$ENV_DIR"/PROJECT_PATH)
 
+if [ ! -d "$BUILD_DIR"/"$PROJECT_PATH" ]; then
+    echo "       No such directory '$PROJECT_PATH.'"
+    exit 2
+fi
 
+echo "       PROJECT_PATH is '$PROJECT_PATH'."
+
+TMP_DIR=$(mktemp -d)
+
+echo "       Created temporary directory '$TMP_DIR'."
+echo "       Moving Heroku application in '$PROJECT_PATH' to '$TMP_DIR'."
+cp -RT "$BUILD_DIR"/"$PROJECT_PATH" "$TMP_DIR"
+
+echo "       Promoting subdirectory contents to root directory."
+echo "         (Copying '$TMP_DIR' to '$BUILD_DIR')"
+rm -rf "$BUILD_DIR"/* # Delete all hidden files.
+cp -RT "$TMP_DIR" "$BUILD_DIR"
+
+echo "       Deleting '$TMP_DIR'."
+rm -rf "$TMP_DIR"


### PR DESCRIPTION
# The problem

The original version of the buildpack deleted too many files from the application root directory. It was deleting dotfiles that were required for certain other buildpacks to function properly. For example, it was deleting `.profile.d` scripts, files required by in-dyno add-ons, and the binary used to set up and run CI tests.

# The solution

Since all of the files that, when deleted, caused problems were dotfiles, I modified the buildpack to leave dotfiles in the root directory untouched. This is a conservative solution, that is to say that it spares too many files such as `.gitignore` from deletion, but I think it is sufficient for now.